### PR TITLE
Move back to simpler syntax for defining supported Rubies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,36 +7,19 @@ env:
     - PATH=/opt/local/bin:$PATH
     - TESTOPTS="-v"
     - TINYTDS_UNIT_HOST=localhost
-matrix:
-  include:
-    - os: linux
-      rvm: 2.3.8
-      install:
-        - gem install bundler
-        - bundle --version
-        - bundle install
-    - os: linux
-      rvm: 2.4.5
-      install:
-        - gem install bundler
-        - bundle --version
-        - bundle install
-    - os: linux
-      rvm: 2.5.3
-      install:
-        - gem install bundler
-        - bundle --version
-        - bundle install
-    - os: linux
-      rvm: 2.6.1
-      install:
-        - gem install bundler
-        - bundle --version
-        - bundle install
+rvm:
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
 before_install:
   - docker info
   - sudo ./test/bin/install-openssl.sh
   - sudo ./test/bin/install-freetds.sh
   - sudo ./test/bin/setup.sh
+install:
+  - gem install bundler
+  - bundle --version
+  - bundle install
 script:
   - bundle exec rake


### PR DESCRIPTION
As all the supported rubies now work with Bundler 2, the install instructions are the same for each and so can be condensed down to the simpler format again.